### PR TITLE
feat: support mid tag wildcard for enabling logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ When the value is set (ex. `DEBUG=example:*,tool:details` and/or `KEMBA=plugin:f
 
 The value of these flags can be a simple regex alternative where a wildcard (`*`) are replaced with `.*` and all terms are prepended with `^` and appended with `$`. If a term does not include a wildcard, then an exact match it required.
 
+Example of a wildcard in the middle of a tag string: `DEBUG=example:*:fxn` will match tags like `[example:tag1:fxn, example:tag2:fxn, example:anything:fxn, ...]`
+
 To disabled colors, set the `NOCOLOR` environment variable to any value.
 
 ![image](https://user-images.githubusercontent.com/1429775/88557149-7973ff80-cfef-11ea-8ec2-ff332fd1b25f.png)

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,13 @@ module github.com/clok/kemba
 go 1.16
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gookit/color v1.5.1
 	github.com/kr/pretty v0.3.0
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/stretchr/testify v1.7.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/kemba.go
+++ b/kemba.go
@@ -273,7 +273,7 @@ func determineEnabled(tag string, allowed string) bool {
 	for _, l := range strings.Split(allowed, ",") {
 		if strings.Contains(l, "*") {
 			reg := strings.ReplaceAll(l, "*", ".*")
-			if !strings.HasPrefix(reg, "^") {
+			if !strings.HasPrefix(reg, "^") && !strings.HasPrefix(reg, "*") {
 				reg = fmt.Sprintf("^%s", reg)
 			}
 

--- a/kemba_test.go
+++ b/kemba_test.go
@@ -65,10 +65,24 @@ func Test_New(t *testing.T) {
 	})
 
 	t.Run("fuzzy match tag", func(t *testing.T) {
+		_ = os.Setenv("DEBUG", "*kemba*")
+
+		k := New("test:kemba:fail")
+		is.True(k.enabled, "Logger should be enabled")
+	})
+
+	t.Run("fuzzy match tag [failure]", func(t *testing.T) {
 		_ = os.Setenv("DEBUG", "*kemba")
 
 		k := New("test:kemba:fail")
 		is.False(k.enabled, "Logger should NOT be enabled")
+	})
+
+	t.Run("fuzzy match tag [mid star]", func(t *testing.T) {
+		_ = os.Setenv("DEBUG", "test:*:fail")
+
+		k := New("test:kemba:fail")
+		is.True(k.enabled, "Logger should be enabled")
 	})
 }
 


### PR DESCRIPTION
Example of a wildcard in the middle of a tag string: `DEBUG=example:*:fxn` will match tags like `[example:tag1:fxn, example:tag2:fxn, example:anything:fxn, ...]`